### PR TITLE
Check pressable widget active

### DIFF
--- a/whitelabel-dashboard.php
+++ b/whitelabel-dashboard.php
@@ -8,28 +8,31 @@ Author: Pressable
 Author URI: https://pressable.com
 License: GPLv2 
 */
-
+ 
 // disable direct file access
 if (!defined('ABSPATH')) {
     exit;
 }
-
+ 
 // plugin can only work for site hosted on Pressable.
 if (!defined('IS_PRESSABLE')) {
     return;
 }
 
-// remove the "Welcome to Pressable" widget box from dashboard
-function remove_pressable_widget_with_plugin() {  // must be different name than identical function used in functions.php so function_exists() isn't accidentally triggered
+// get some info about active theme and its functions.php
+$active_theme_slug = get_stylesheet(); // get active theme's slug as a string
+$theme_functions = file_get_contents(WP_CONTENT_DIR . '/themes/' . $active_theme_slug . '/functions.php'); // get contents active theme's functions.php as a string
+ 
+// what are we looking for in the theme's functions.php?
+$function_name = 'remove_pressable_widget';
+ 
+// remove the "Welcome to Pressable" widget box from dashboard if functions.php isn't already removing it
+function remove_pressable_widget_with_plugin() {
+    if (!strpos($theme_functions, $function_name)) { 
         remove_meta_box( 'pressable_dashboard_widget', 'dashboard', 'normal' );
-}
-
-// if pressable widget is active, remove it
-function remove_widget_if_active() {
-        if (!function_exists('remove_pressable_widget')) {
-            add_action('wp_dashboard_setup', 'remove_pressable_widget_with_plugin' );
     }
 }
 
 add_action('wp_dashboard_setup', 'remove_pressable_widget_with_plugin');
+
 ?>

--- a/whitelabel-dashboard.php
+++ b/whitelabel-dashboard.php
@@ -3,7 +3,7 @@
 Plugin Name: White-label Dashboard
 Plugin URI: https://pressable.com
 Description: This plugin removes the web host's banner from the WordPress admin dashboard
-Version: 1.0.1
+Version: 1.0.2
 Author: Pressable
 Author URI: https://pressable.com
 License: GPLv2 
@@ -13,26 +13,26 @@ License: GPLv2
 if (!defined('ABSPATH')) {
     exit;
 }
- 
+
 // plugin can only work for site hosted on Pressable.
 if (!defined('IS_PRESSABLE')) {
     return;
 }
 
-// get some info about active theme and its functions.php
-$active_theme_slug = get_stylesheet(); // get active theme's slug as a string
-$theme_functions = file_get_contents(WP_CONTENT_DIR . '/themes/' . $active_theme_slug . '/functions.php'); // get contents active theme's functions.php as a string
- 
-// what are we looking for in the theme's functions.php?
-$function_name = 'remove_pressable_widget';
- 
 // remove the "Welcome to Pressable" widget box from dashboard if functions.php isn't already removing it
 function remove_pressable_widget_with_plugin() {
+
+// get some info about active theme and its functions.php
+    $active_theme_slug = get_stylesheet(); // get active theme's slug as a string
+    $theme_functions = file_get_contents(WP_CONTENT_DIR . '/themes/' . $active_theme_slug . '/functions.php'); // get conte$
+ 
+// what are we looking for in the theme's functions.php?
+    $function_name = 'remove_pressable_widget';
+ 
+
     if (!strpos($theme_functions, $function_name)) { 
         remove_meta_box( 'pressable_dashboard_widget', 'dashboard', 'normal' );
     }
 }
 
 add_action('wp_dashboard_setup', 'remove_pressable_widget_with_plugin');
-
-?>

--- a/whitelabel-dashboard.php
+++ b/whitelabel-dashboard.php
@@ -3,7 +3,7 @@
 Plugin Name: White-label Dashboard
 Plugin URI: https://pressable.com
 Description: This plugin removes the web host's banner from the WordPress admin dashboard
-Version: 1.0.0
+Version: 1.0.1
 Author: Pressable
 Author URI: https://pressable.com
 License: GPLv2 
@@ -19,10 +19,15 @@ if (!defined('IS_PRESSABLE')) {
     return;
 }
 
-// remove the "Welcome to Pressable" widget box from dashboard when it is loaded
-function remove_pressable_widget() {
-		remove_meta_box( 'pressable_dashboard_widget', 'dashboard', 'normal' );
-    }
+// remove the "Welcome to Pressable" widget box from dashboard
+function remove_pressable_widget_with_plugin() {  // must be different name than identical function used in functions.php so function_exists() isn't accidentally triggered
+        remove_meta_box( 'pressable_dashboard_widget', 'dashboard', 'normal' );
+}
 
-add_action('wp_dashboard_setup', 'remove_pressable_widget' );
+// if pressable widget is active, remove it
+function remove_widget_if_active() {
+        if (!function_exists('remove_pressable_widget')) {
+            add_action('wp_dashboard_setup', 'remove_pressable_widget_with_plugin' );
+    }
+}
 ?>

--- a/whitelabel-dashboard.php
+++ b/whitelabel-dashboard.php
@@ -30,4 +30,6 @@ function remove_widget_if_active() {
             add_action('wp_dashboard_setup', 'remove_pressable_widget_with_plugin' );
     }
 }
+
+add_action('wp_dashboard_setup', 'remove_pressable_widget_with_plugin');
 ?>


### PR DESCRIPTION
Moved some variables inside the core function to resolve a deprecated warning from PHP 8.x

Tested on PHP 8 and PHP 7.4.